### PR TITLE
Abbreviate license name

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,7 +62,7 @@
 		<footer>
 			<p><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" /></a>
 			<br />
-			This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>. Copyright 2019 <a href="https://github.com/a11y-reviews/a11y.reviews/graphs/contributors">a11y.reviews contributors</a>.
+			This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><abbr title="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License">CC BY-NC-SA 4.0</abbr></a>. Copyright 2019 <a href="https://github.com/a11y-reviews/a11y.reviews/graphs/contributors">a11y.reviews contributors</a>.
 			<br />
 			<a href="https://github.com/a11y-reviews/a11y.reviews/edit/master/{{ page.path }}">Edit this page</a> or <a href="https://github.com/a11y-reviews/a11y.reviews/issues/new">file an issue</a> on GitHub.</p>
 		</footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,7 +62,7 @@
 		<footer>
 			<p><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" /></a>
 			<br />
-			This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International LicenseCC BY-NC-SA 4.0</a> (CC BY-NC-SA 4.0). Copyright 2019 <a href="https://github.com/a11y-reviews/a11y.reviews/graphs/contributors">a11y.reviews contributors</a>.
+			This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a> (CC BY-NC-SA 4.0). Copyright 2019 <a href="https://github.com/a11y-reviews/a11y.reviews/graphs/contributors">a11y.reviews contributors</a>.
 			<br />
 			<a href="https://github.com/a11y-reviews/a11y.reviews/edit/master/{{ page.path }}">Edit this page</a> or <a href="https://github.com/a11y-reviews/a11y.reviews/issues/new">file an issue</a> on GitHub.</p>
 		</footer>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,7 +62,7 @@
 		<footer>
 			<p><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" /></a>
 			<br />
-			This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><abbr title="Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License">CC BY-NC-SA 4.0</abbr></a>. Copyright 2019 <a href="https://github.com/a11y-reviews/a11y.reviews/graphs/contributors">a11y.reviews contributors</a>.
+			This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International LicenseCC BY-NC-SA 4.0</a> (CC BY-NC-SA 4.0). Copyright 2019 <a href="https://github.com/a11y-reviews/a11y.reviews/graphs/contributors">a11y.reviews contributors</a>.
 			<br />
 			<a href="https://github.com/a11y-reviews/a11y.reviews/edit/master/{{ page.path }}">Edit this page</a> or <a href="https://github.com/a11y-reviews/a11y.reviews/issues/new">file an issue</a> on GitHub.</p>
 		</footer>


### PR DESCRIPTION
This adds an `<abbr>` for the license name and displays the license shortname instead (CC BY-NC-SA 4.0).