### PR TITLE
Spell out title

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: a11y.reviews
+title: Accessibility Reviews
 description: Community reviews on the accessibility of tools and services.
 ---
 


### PR DESCRIPTION
This will spell out the title instead of keeping it as the URL.